### PR TITLE
Fix SVG sizing

### DIFF
--- a/tools/renderer/index.html
+++ b/tools/renderer/index.html
@@ -70,9 +70,9 @@
         var shaMargin = 60;
 
         var svg = d3.select($('#tree')[0]);
-        svg.style('height', (_.max(tree, 'idx').idx+1)* yGap + radius);
+        svg.style('height', (_.max(tree, 'idx').idx+1)* yGap + 2 * radius + 'px');
         svg.selectAll('*').remove();
-        var sg = svg.append('g')
+        var sg = svg.append('g').attr('transform', 'translate(0, ' + radius + ')' )
 
         var lineFunction = d3.svg.line()
           .x(function(d) { return d.x; })


### PR DESCRIPTION
Currently the SVG size is not updated in Firefox.

Also, the text of the first commit hash is truncated, regardless of which browser is used.

This PR fixes both issues.

## Before

![old](https://user-images.githubusercontent.com/338833/102375651-ab93f700-3fba-11eb-9298-009ffeec3e1d.png)

## After

![new](https://user-images.githubusercontent.com/338833/102375670-af277e00-3fba-11eb-9b0c-58ef6ffd2f34.png)
